### PR TITLE
expected length of curl output is now the third argument to fmt_wttr

### DIFF
--- a/weather
+++ b/weather
@@ -92,8 +92,8 @@ fi
 # To extract tail, awk builds a buffer and begins printing it only after NR>xt e.g. a[1] is printed when a[xt] is being recorded
 
 function fmt_wttr {
-  # $1=xh, $2=xt e.g. to exclude 3 lines from head and 5 from tail: fmt_wttr 3 5
-  curl -s http://wttr.in/$city 2> /dev/null | awk -v xt=$2 '{if(NR>xt) print a[NR%xt]; a[NR%xt]=$0}' | awk -v xh=$1 'NR>xh{print $0}'
+  # $1=xh, $2=xt, $3=rawlen e.g. to exclude 3 lines from head and 5 from tail from 50 lines of raw output: fmt_wttr 3 5 50
+  curl -s http://wttr.in/$city 2> /dev/null | awk -v xt=$2 -v len=$3 '{if(NR>xt) print a[NR%xt]; a[NR%xt]=$0; i++; if (i>len) exit}' | awk -v xh=$1 'NR>xh{print $0}'
 }
 
 function fmt_moon {
@@ -101,21 +101,21 @@ function fmt_moon {
 }
 
 if  [[ $three = true ]]; then
-  fmt_wttr 0 2
+  fmt_wttr 0 2 39
 elif [[ $today || $tomorrow || $nextday = true ]]; then
   if [[ $today = true ]]; then
-    fmt_wttr 7 23
+    fmt_wttr 7 23 39
   fi
   if [[ $tomorrow = true ]]; then
-    fmt_wttr 17 13
+    fmt_wttr 17 13 39
   fi
   if [[ $nextday = true ]]; then
-    fmt_wttr 27 3
+    fmt_wttr 27 3 39
   fi
 elif [[ $moon = true ]]; then
   fmt_moon
 elif [[ $nodisplaylocation = true ]]; then
-  fmt_wttr 1 33
+  fmt_wttr 1 33 39
   echo ""
 else
   curl -s http://wttr.in/ 2> /dev/null | awk -v xt=33 '{if(NR>xt) print a[NR%xt]; a[NR%xt]=$0}'


### PR DESCRIPTION
wttr's output can change without notice so probably the real solution is pattern matching

in the meantime this stops awk from processing records after a certain number have been read

